### PR TITLE
Change kanjiSelectionBox to float right

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -25,11 +25,8 @@ body {
 
 /*Kanji Selector */
 #kanjiSelectionBox {
-  position: fixed;
-  height: 515px;
-  overflow: scroll;
   width: 25%;
-  right: 0;
+  float: right;
   padding: 0 15px 15px 15px;
   border-left: 1px solid #000;
   background: rgba(255, 255, 255, 0.8);


### PR DESCRIPTION
Right now it looks kinda weird on my screen ([screenshot](http://media-cache-ak0.pinimg.com/originals/11/2f/fa/112ffa32f870f00e5e3f480ba7b29cad.jpg)) -> [after](http://media-cache-ec0.pinimg.com/originals/77/84/bc/7784bcb212ab978fd83176f3271110a7.jpg)

This fix just pushes the content around the kanjiSelectionBox.

Might also be worthwhile to just `.kanji-row` a 75% width with `#kanjiSelectionBox` getting `top: 0; padding: 15px 15px 15px 15px;` if you want the selection box to scroll along with you. I can open this as a PR instead if you'd like.
