### PR TITLE
All-levels Wani Kani, and print break.

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -84,6 +84,7 @@ body {
   padding: 15px;
   border-left: 1px solid #000;
   background: rgba(255, 255, 255, 0.8);
+  overflow: scroll;
 }
 
 #kanjiSelectionBox .kanji-box {
@@ -182,7 +183,8 @@ body {
 
 @media print {
   .kanji-row {
-    width: 980px;
+    width: 100%;
+    page-break-inside: avoid;
   }
 
   #kanjiSelectionBox {

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <title>cards</title>
+    <title>Kanji Sheets</title>
     <link href="/css/main.css" rel="stylesheet" type="text/css" />
 
     <script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
@@ -10,8 +10,8 @@
     <div id="container">
 
       <header id="header">
-	<h1>Kanji Worksheets</h1>
-  </header> <!-- HEADER -->
+         <h1>Kanji Worksheets</h1>
+      </header> <!-- HEADER -->
 
       <div id="kanjiSelectionBox">
         <div class="categoryBox">
@@ -20,36 +20,41 @@
             <div class="kanjiStrokes">
               <span>Strokes:</span> <span class="strokeToggle">&nbsp;</span>
             </div>
-
           </div>
           <div class="settings-content">
           </div>
         </div>
+
         <div class="categoryBox" data-category="jlptn5">
           <h2 class="category">JLPT N5</h2>
           <div class="category-content expand">
           </div>
         </div>
+
         <div class="categoryBox" data-category="jlptn4">
           <h2 class="category">JLPT N4</h2>
           <div class="category-content">
           </div>
         </div>
+
         <div class="categoryBox" data-category="jlptn3">
           <h2 class="category">JLPT N3</h2>
           <div class="category-content">
           </div>
         </div>
+
         <div class="categoryBox" data-category="jlptn2">
           <h2 class="category">JLPT N2</h2>
           <div class="category-content">
           </div>
         </div>
+
         <div class="categoryBox" data-category="jlptn1">
           <h2 class="category">JLPT N1</h2>
           <div class="category-content">
           </div>
         </div>
+
         <div class="categoryBox" data-category="wanikani">
           <h2 class="category">Wani Kani</h2>
           <div class="category-content">

--- a/js/waniKani.js
+++ b/js/waniKani.js
@@ -27,7 +27,7 @@ window.WaniKani = {
 
   loadUser: function(apiKey) {
     $.ajax({
-      url: 'https://www.wanikani.com/api/user/'+ apiKey +'/kanji/1',
+      url: 'https://www.wanikani.com/api/user/'+ apiKey +'/kanji/',
       type: 'GET',
       dataType: 'jsonp',
 


### PR DESCRIPTION
I was only grabbing the first level of a user's Wani Kani kanji, but that is now fixed! I also added a print-break to ensure that kanji rows are grouped on pages with their corresponding boxes. (Thanks rfindley from WaniKani.com for the idea!) 

:tulip::tulip::tulip::tulip::tulip::tulip::tulip::tulip::tulip::tulip::tulip::tulip::tulip::tulip::tulip::tulip::tulip::tulip::tulip::tulip::tulip::tulip::tulip::tulip::tulip::tulip::tulip::tulip::tulip::tulip::tulip::tulip::tulip:
