### PR TITLE
Fix: Add 'clone()' to creation of WaniKani level subcategories

### DIFF
--- a/js/waniKani.js
+++ b/js/waniKani.js
@@ -31,7 +31,7 @@ window.WaniKani = {
     for(i=1; i<=userLevel; i++){
       $subLevelTemplate.attr('data-subcategory', i);
       $subLevelTitle.text('Level '+ i);
-      $category.append($subLevelTemplate);
+      $category.append($subLevelTemplate.clone());
     };
   },
 


### PR DESCRIPTION
$subCategory object is being repeatedly modified, and append() keeps moving the object within the DOM.  Adding clone() creates a new object for each subcategory.
